### PR TITLE
fix assertions for angler mdb08l

### DIFF
--- a/jni/extract.c
+++ b/jni/extract.c
@@ -87,7 +87,8 @@ int main(int argc, char **argv) {
 	assert(
 			hdr->page_size == 2048 ||
 			hdr->page_size == 4096 ||
-			hdr->page_size == 16384
+			hdr->page_size == 16384 ||
+			hdr->page_size == 32767
 			);
 
 	long pos = hdr->page_size;

--- a/jni/repack.c
+++ b/jni/repack.c
@@ -89,7 +89,8 @@ int main(int argc, char **argv) {
 	assert(
 			ihdr->page_size == 2048 ||
 			ihdr->page_size == 4096 ||
-			ihdr->page_size == 16384
+			ihdr->page_size == 16384 ||
+			ihdr->page_size == 32767
 			);
 
 	unlink("new-boot.img");


### PR DESCRIPTION
The page size of the mdb08l boot.img is 32767. Assertions need to be
updated for super-bootimg to do its thing.
