### PR TITLE
allow multiple directories to be cleaned up

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -11,7 +11,7 @@ trap clean EXIT
 
 function mktempd() {
 	d="$(mktemp -d)"
-	TOCLEAN+="$d"
+	TOCLEAN+=" $d"
 }
 
 list="$1"


### PR DESCRIPTION
When two or more directories are created, the TOCLEAN varibale
would get set such that the names were combined, for example:
  "/tmp/tmp.yPVhYrqh7B/tmp/tmp.LyRBDyiGew"
By prepending a space, we get something like:
  " /tmp/tmp.yPVhYrqh7B /tmp/tmp.LyRBDyiGew"
which will be passed to the "rm" command.
