### PR TITLE
Update FP2 to v. 1.4.2

### DIFF
--- a/known-imgs/fairphone/fp2
+++ b/known-imgs/fairphone/fp2
@@ -1,2 +1,2 @@
-http://storage.googleapis.com/fairphone-updates/FP2-gms43-1.2.8-ota.zip
+http://storage.googleapis.com/fairphone-updates/FP2-gms54-1.3.6-ota.zip
 boot.img

--- a/known-imgs/fairphone/fp2
+++ b/known-imgs/fairphone/fp2
@@ -1,2 +1,2 @@
-http://storage.googleapis.com/fairphone-updates/FP2-gms54-1.3.6-ota.zip
+http://storage.googleapis.com/fairphone-updates/FP2-gms56-1.4.2-ota.zip
 boot.img


### PR DESCRIPTION
Fairphone just released Version 1.3.6 of Fairphone OS
(see [here](https://forum.fairphone.com/t/fairphone-os-1-3-6-update/18090/))
