### PR TITLE
Update FP2 to 1.6.2

### DIFF
--- a/known-imgs/fairphone/fp2
+++ b/known-imgs/fairphone/fp2
@@ -1,2 +1,2 @@
-http://storage.googleapis.com/fairphone-updates/FP2-gms59-1.5.1-ota.zip
+http://storage.googleapis.com/fairphone-updates/526aa40f-3657-4c85-82ef-ff82ebc3d1b1/FP2-gms63-1.6.2-ota.zip
 boot.img


### PR DESCRIPTION
See [here](https://forum.fairphone.com/t/fairphone-os-1-6-2-is-available/21257) for release notes.
