### PR TITLE
[2/2] Silence "KERNEL IS NOT SEANDROID ENFORCING"

### DIFF
--- a/scripts/bootimg.sh
+++ b/scripts/bootimg.sh
@@ -222,3 +222,8 @@ if [ -n "$CHROMEOS" ];then
 
 	rm -f toto1 toto2 output.keyblock
 fi
+
+# Silence warning when boot on Samsung phones
+if getprop ro.product.manufacturer | grep -iq '^samsung$'; then
+	echo "SEANDROIDENFORCE" >> "new-boot.img"
+fi


### PR DESCRIPTION
- Silence warning when boot on Samsung phones
