### PR TITLE
Fix =~ bash operator detection

### DIFF
--- a/scripts/bootimg.sh
+++ b/scripts/bootimg.sh
@@ -66,7 +66,7 @@ startBootImgEdit() {
 	fi
 }
 
-[[ "toto2" =~ "toto" ]] && good_expr=1
+$([[ "toto2" =~ "toto" ]]) && good_expr=1
 
 addFile() {
 	#WARNING FIXME: If you want to add toto and toto2


### PR DESCRIPTION
There is a problem with the "=~" operator support detection (and maybe the shell -e option).
As the command fails, the script stops.
So the command should be in a subshell if you would like to test its support without breaking the whole script.