### PR TITLE
Call custom boot image patcher script

### DIFF
--- a/scripts/bootimg.sh
+++ b/scripts/bootimg.sh
@@ -226,6 +226,11 @@ if [ -n "$CHROMEOS" ];then
 	rm -f toto1 toto2 output.keyblock
 fi
 
+# Call custom boot image patch script
+if [ -f "/data/custom_boot_image_patch.sh" ]; then
+	sh -x /data/custom_boot_image_patch.sh new-boot.img
+fi
+
 # Silence warning when boot on Samsung phones
 # XXX: This check ONLY works on LIVE devices, not from script
 # Here this is not a problem because the change is purely cosmetic, but don't rely on this if for anything else


### PR DESCRIPTION
Some devices (e.g. [LG G3](https://forum.xda-developers.com/lg-g2/general/bump-supersu-t3273251)) require custom boot image patching. 
SuperSU installer calls `/data/custom_boot_image_patch.sh` for this purpose. 
This pull request adds calling `/data/custom_boot_image_patch.sh`.